### PR TITLE
Fix recursive navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+group :jekyll_plugins do
+  gem 'jekyll-redirect-from'
+  gem 'jekyll-seo-tag'
+  gem 'jekyll-sitemap'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,10 +47,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (= 3.4.2)
+  jekyll
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/_includes/all-projects-nav.html
+++ b/_includes/all-projects-nav.html
@@ -1,6 +1,8 @@
-{% assign all_project_pages = site.projects | sort: "path" | sort: "position" %}
+{% assign url_parts = page.url | split: "/" %}
+{% capture this_project_folder %}/{{ url_parts[1] }}/{{ url_parts[2] }}/{% endcapture %}
 
-{% assign this_project_folder = page.path | remove: "_projects/" | split: "/" | first | prepend: "/_projects/" | append: "/" %}
+{% assign all_project_pages = site.projects | where_exp: "item", "item.url contains this_project_folder" | sort: "path" | sort: "position" %}
+
 {% capture same_project_pages %}
 <nav>
   {% include recursive-nav.html items=all_project_pages base_path=this_project_folder %}

--- a/_includes/recursive-nav.html
+++ b/_includes/recursive-nav.html
@@ -1,11 +1,8 @@
 {% capture list_items %}
 
   {% for item in include.items %}
-
-    {% assign item_slug = item.path  | remove: ".md" | split: "/" | last | append: "/" %}
-    {% assign parent_slug = item.path  | remove: ".md" | prepend: "/" | append: "/" | remove: item_slug %}
-
-    {% if parent_slug == include.base_path %}
+    {% assign parent_url = item.url | split: "/" | pop | join: "/" | append: "/" %}
+    {% if parent_url == include.base_path %}
       <li>
         {% unless item.layout == "redirect" %}
           <a href="{{ site.baseurl }}{{ item.url }}"{% if page.url == item.url %}class="active"{% elsif page.url contains item.url %}class="active-parent"{% endif %} title="{{ item.title }}" role="menuitem">{{ item.title }}</a>
@@ -17,8 +14,7 @@
             <p class="project-date">{{ site.data.labels.last_revision_prefix }} {{ item.date | date: '%B %e, %Y' }}</p>
           {% endunless %}
         {% endunless %}
-        {% assign inner_base_path = item.path | remove: ".md" | prepend: "/" | append: "/" %}
-        {% include recursive-nav.html items=include.items base_path=inner_base_path recursive=true %}
+        {% include recursive-nav.html items=include.items base_path=item.url recursive=true %}
       </li>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
After discussing on Slack with @amenity, I found 2 issues with the recursive navigation:

1. The code was only taking into consideration files named `.md` (not `.markdown`) so some documents were getting missed https://github.com/cityofaustin/innovation-projects/blob/2b73bab5b4bcd3efc4b65718bf31e06eb6c0eaba/_includes/recursive-nav.html#L5 

2. The page `discovery` was not being shown because its parent is called `austin-digital-services-discovery`. Since both of those slugs contain `discovery`, your recursive nav loop didn't know how to handle.

This PR fixes both above issues and improves performance.

I also added a `Gemfile` as it looks like this project was missing one.